### PR TITLE
Use base64 encoded service account secret

### DIFF
--- a/plan_dinners.py
+++ b/plan_dinners.py
@@ -1,6 +1,7 @@
 import os
 import json
 import random
+import base64
 import pandas as pd
 from datetime import date
 from googleapiclient.discovery import build
@@ -30,7 +31,10 @@ class PlanDinners:
                 "Please set the SERVICE_ACCOUNT environment variable to the contents of your service account JSON file."
             )
         self.credentials = service_account.Credentials.from_service_account_info(
-            info=json.loads(service_account_info),
+            info=json.loads(
+                # The JSON string is B64-encoded to avoid newlines causing issues in the pipeline
+                base64.b64decode(service_account_info.encode("ascii"))
+            ),
             scopes=['https://www.googleapis.com/auth/spreadsheets']
         )
 

--- a/plan_dinners.py
+++ b/plan_dinners.py
@@ -143,11 +143,11 @@ class PlanDinners:
     def export(self):
         """Schedule meals, create shopping list, and update a Google Sheet with Meals and Shopping sheets"""
 
-        # Pick meals and create shopping list
+        """Pick meals and create shopping list"""
         PlanDinners.schedule_meals(self)
         PlanDinners.shopping(self)
 
-        # Update Google Sheet with latest meal plan
+        """Update Google Sheet with latest meal plan"""
         PlanDinners.update_sheet(
             self,
             "Meals!A:E",

--- a/plan_dinners.py
+++ b/plan_dinners.py
@@ -32,7 +32,7 @@ class PlanDinners:
             )
         self.credentials = service_account.Credentials.from_service_account_info(
             info=json.loads(
-                # The JSON string is B64-encoded to avoid newlines causing issues in the pipeline
+                # The JSON string is B64-encoded to avoid control chars causing issues in the pipeline
                 base64.b64decode(service_account_info.encode("ascii"))
             ),
             scopes=['https://www.googleapis.com/auth/spreadsheets']


### PR DESCRIPTION
The newlines in the secret are causing it to be passed in improperly. This is resolved by Base64 encoding the secret so that it is a simple string with no control chars, then just decoding it before use.