### PR TITLE
Load dotenv for local environment vars

### DIFF
--- a/plan_dinners.py
+++ b/plan_dinners.py
@@ -7,6 +7,9 @@ import datetime
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
 from googleapiclient.errors import HttpError
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 class PlanDinners:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
+python-dotenv
 google-api-python-client


### PR DESCRIPTION
When working locally (not running in a GitHub Action), the `SERVICE_ACCOUNT` and `SPREADSHEET_ID` environment variables will be loaded from your untracked `.env` file. This allows you to have the secrets loaded without having them shared publicly.

At the root of your repo create a file name `.env` with the contents like so:
```env
SERVICE_ACCOUNT=base64_string_here
SPREADSHEET_ID=id_here
```

This file is gitignored, so it won't be committed or altered by any version control actions.