### PR TITLE
Scale category logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ Example:
    ![image](https://github.com/Ho1yShif/dinner/assets/40185666/2c688c51-7fac-4ad9-b3f6-7f885b261be1)
 
 2. Set up a Google Cloud service account with access to the Google Sheets API and create a new JSON key ([Learn more about Service Accounts.](https://cloud.google.com/iam/docs/service-account-overview?authuser=4))
+
    - Replace the `\n` in the key with `\\n` so Python's json library can parse it
    - Encode the santized key JSON in base64 so it can be easily stored in GitHub Secrets
 
 3. Fork this repo
+
    - Customize your meal plan using the `dinners.json` file
 
 4. Set repo actions Secrets
-    - `SERVICE_ACCOUNT` is the Google service account JSON file encoded in base64
-    - `SPREADSHEET_ID` is the ID of your Google Sheet (the long string in the URL)
+   - `SERVICE_ACCOUNT` is the Google service account JSON file encoded in base64
+   - `SPREADSHEET_ID` is the ID of your Google Sheet (the long string in the URL)
 
 ## How it works
 
-A GitHub Action is scheduled to run the `plan_dinners.py` script weekly at 3 AM on Saturday. This script will read the `dinners.json` file and randomly select meals for each day of the week. Each meal category will be represented only once per week to avoid repetition.
+A GitHub Action is scheduled to run the `plan_dinners.py` script weekly at 3 AM on Saturday. This script will read the `dinners.json` file and randomly select meals for each day of the week.
+
+Each meal category is represented non-consecutively throughout the week, meaning that the same meal category won't be used two days in a row.
 
 After making selections, the script then updates the `Meals` sheet with the chosen meals and updates the `Shopping` sheet with the ingredients needed for those meals. The shopping list will also include a reminder to check if you are stocked on staples like eggs, bread, oil, etc.

--- a/plan_dinners.py
+++ b/plan_dinners.py
@@ -55,21 +55,17 @@ class PlanDinners:
 
     def schedule_meals(self):
         """Build meal schedule for the week along with ingredients and ahead-of-time prep instructions"""
-
         meal_options = list(self.meals.keys())
-        chosen_meals, meal_categories = [], []
+        chosen_meals = []
+        last_category = None
 
         """Randomly select 3 meals for the weekly schedule"""
         while len(chosen_meals) < 3:
             chosen_meal = random.choice(meal_options)
-            category = self.meals[chosen_meal]["category"]
-            """
-            Allow for only one meal per category per week
-            TODO: This can be done more elegantly by bucketing meals into
-            categories, then picking random category buckets and removing the category once used
-            """
-            if category not in meal_categories:
-                meal_categories.append(category)
+            curr_category = self.meals[chosen_meal]["category"]
+            """Ensure that meals from the same category won't be scheduled on consecutive days"""
+            if curr_category != last_category:
+                last_category = curr_category
                 meal_options.remove(chosen_meal)
                 chosen_meals.append(chosen_meal)
             else:
@@ -123,7 +119,6 @@ class PlanDinners:
              "Veggies and Toppings": veggies_toppings,
              "Meal Ingredients": shopping_list}
         )
-
         return self.shopping_df
 
     def update_sheet(self, range_name, value_input_option, values):


### PR DESCRIPTION
@boatbomber suggested that we bucket the categories to keep them unique for each week, but I decided to take a different approach that will scale better.

Assuming we decide to use this program for Thursday and Friday meals as well, we can accommodate the same category twice in a week; we just don't want to eat the same meal category two consecutive days in a row. 

I implemented this logic in `plan_dinners.py` and updated the `README` accordingly.